### PR TITLE
Rewrite the Webhooks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ This sample application provides a simple webhook integration exposed at `/api/w
 
 ### Making your server reachable
 
-Your endpoint consuming the incoming webhook notifications must be accessible by Adyen (ie public access).
+Your endpoint that will consume the incoming webhook must be publicly accessible.
+
 There are typically 3 options:
 * deploy on your own cloud provider
 * deploy on Gitpod

--- a/README.md
+++ b/README.md
@@ -83,6 +83,62 @@ npm run dev
 
 To try out integrations with test card numbers and payment method details, see [Test card numbers](https://docs.adyen.com/development-resources/test-cards/test-card-numbers).
 
+## Testing webhooks
+
+Webhooks deliver asynchronous notifications (like payment status) and it is important to test them during the setup of your integration. You can find more information about webhooks in [this detailed blog post](https://www.adyen.com/blog/Integrating-webhooks-notifications-with-Adyen-Checkout).
+
+This sample application provides a simple webhook integration exposed at `/api/webhooks/notifications`. For it to work, you need to:
+
+1. Provide a way for the Adyen platform to reach your running application
+2. Add a Standard webhook in your Customer Area
+
+### Making your server reachable
+
+Your endpoint consuming the incoming webhook notifications must be accessible by Adyen (ie public access).
+There are typically 3 options:
+* deploy on your own cloud provider
+* deploy on Gitpod
+* expose your localhost with tunneling software (i.e. ngrok)
+
+#### Option 1: cloud deployment
+If you deploy on your cloud provider (or your own public server) the webhook URL will be the URL of the server 
+```
+  https://{cloud-provider}/api/webhooks/notifications
+```
+
+#### Option 2: Gitpod
+If you use Gitpod the webhook URL will be the host assigned by Gitpod
+```
+  https://myorg-myrepo-y8ad7pso0w5.ws-eu75.gitpod.io/api/webhooks/notifications
+```
+**Note:** when starting a new Gitpod workspace the host changes, make sure to **update the Webhook URL** in the Customer Area
+
+#### Option 3: localhost via tunneling software
+If you use a tunneling service like [ngrok](ngrok) the webhook URL will be the generated URL (ie `https://c991-80-113-16-28.ngrok.io`)
+
+```bash
+  $ ngrok http 8080
+  
+  Session Status                online                                                                                           
+  Account                       ############                                                                      
+  Version                       #########                                                                                          
+  Region                        United States (us)                                                                                 
+  Forwarding                    http://c991-80-113-16-28.ngrok.io -> http://localhost:8080                                       
+  Forwarding                    https://c991-80-113-16-28.ngrok.io -> http://localhost:8080           
+```
+
+**Note:** when restarting ngrok a new URL is generated, make sure to **update the Webhook URL** in the Customer Area
+
+### Set up a webhook
+
+* In the Customer Area go to Developers -> Webhooks and create a new 'Standard notification' webhook.
+* Enter the URL of your application/endpoint (see options [above](#making-your-server-reachable))
+* Generate the HMAC Key
+* Optionally, in Additional settings, add the data you want to receive. A good example is 'Payment Account Reference'.
+* Make sure the webhook is **Enabled** (therefore it can receive the notifications)
+
+That's it! Every time you perform a new payment, your application will receive a notification from the Adyen platform.
+
 ## Contributing
 
 We commit all our new features directly into our GitHub repository. Feel free to request or suggest new features or code changes yourself as well!

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ To try out integrations with test card numbers and payment method details, see [
 
 ## Testing webhooks
 
-Webhooks deliver asynchronous notifications (like payment status) and it is important to test them during the setup of your integration. You can find more information about webhooks in [this detailed blog post](https://www.adyen.com/blog/Integrating-webhooks-notifications-with-Adyen-Checkout).
+Webhooks deliver asynchronous notifications and it is important to test them during the setup of your integration. You can find more information about webhooks in [this detailed blog post](https://www.adyen.com/blog/Integrating-webhooks-notifications-with-Adyen-Checkout).
 
 This sample application provides a simple webhook integration exposed at `/api/webhooks/notifications`. For it to work, you need to:
 
@@ -133,8 +133,9 @@ If you use a tunneling service like [ngrok](ngrok) the webhook URL will be the g
 
 * In the Customer Area go to Developers -> Webhooks and create a new 'Standard notification' webhook.
 * Enter the URL of your application/endpoint (see options [above](#making-your-server-reachable))
+* Define username and password for Basic Authentication
 * Generate the HMAC Key
-* Optionally, in Additional settings, add the data you want to receive. A good example is 'Payment Account Reference'.
+* Optionally, in Additional Settings, add the data you want to receive. A good example is 'Payment Account Reference'.
 * Make sure the webhook is **Enabled** (therefore it can receive the notifications)
 
 That's it! Every time you perform a new payment, your application will receive a notification from the Adyen platform.


### PR DESCRIPTION
I have grabbed the Testing Webhooks section from the Java Sample app and improved/changed as following:
* add 3 options to deploy webhooks (cloud, gitpod, localhost)
* add notes to update webhook URL when Gitpod or ngrok restart
* add reminder to generate HMAC key and enable the webhook