### PR TITLE
Webhook processing: 202 response with empty body

### DIFF
--- a/authorisation-adjustment-example/index.js
+++ b/authorisation-adjustment-example/index.js
@@ -340,7 +340,7 @@ app.post("/admin/reversal-payment", async (req, res) => {
 /* ################# WEBHOOK ###################### */
 
 // Process incoming Webhook: get NotificationRequestItem, validate HMAC signature,
-// consume the event asynchronously, send response ["accepted"]
+// consume the event asynchronously, send response status code 202
 app.post("/api/webhooks/notifications", async (req, res) => {
 
   // YOUR_HMAC_KEY from the Customer Area
@@ -365,10 +365,10 @@ app.post("/api/webhooks/notifications", async (req, res) => {
     consumeEvent(notification);
 
     // acknowledge event has been consumed
-    res.send('[accepted]')
+    res.status(202).send(); // Send a 202 response with an empty body
 
   } else {
-    // invalid hmac: do not send [accepted] response
+    // invalid hmac
     console.log("Invalid HMAC signature: " + notification);
     res.status(401).send('Invalid HMAC signature');
   }

--- a/checkout-example-advanced/index.js
+++ b/checkout-example-advanced/index.js
@@ -208,7 +208,7 @@ app.get("/result/:type", (req, res) =>
 /* ################# WEBHOOK ###################### */
 
 // Process incoming Webhook: get NotificationRequestItem, validate HMAC signature,
-// consume the event asynchronously, send response ["accepted"]
+// consume the event asynchronously, send response status code 202
 app.post("/api/webhooks/notifications", async (req, res) => {
 
   // YOUR_HMAC_KEY from the Customer Area
@@ -233,10 +233,10 @@ app.post("/api/webhooks/notifications", async (req, res) => {
     consumeEvent(notification);
 
     // acknowledge event has been consumed
-    res.send('[accepted]')
+    res.status(202).send(); // Send a 202 response with an empty body
 
   } else {
-    // invalid hmac: do not send [accepted] response
+    // invalid hmac
     console.log("Invalid HMAC signature: " + notification);
     res.status(401).send('Invalid HMAC signature');
   }

--- a/checkout-example/index.js
+++ b/checkout-example/index.js
@@ -111,7 +111,7 @@ app.get("/result/:type", (req, res) =>
 /* ################# WEBHOOK ###################### */
 
 // Process incoming Webhook: get NotificationRequestItem, validate HMAC signature,
-// consume the event asynchronously, send response ["accepted"]
+// consume the event asynchronously, send response status code 202
 app.post("/api/webhooks/notifications", async (req, res) => {
 
   // YOUR_HMAC_KEY from the Customer Area
@@ -136,10 +136,10 @@ app.post("/api/webhooks/notifications", async (req, res) => {
     consumeEvent(notification);
 
     // acknowledge event has been consumed
-    res.send('[accepted]')
+    res.status(202).send(); // Send a 202 response with an empty body
 
   } else {
-    // invalid hmac: do not send [accepted] response
+    // invalid hmac
     console.log("Invalid HMAC signature: " + notification);
     res.status(401).send('Invalid HMAC signature');
   }

--- a/giftcard-example/index.js
+++ b/giftcard-example/index.js
@@ -121,7 +121,7 @@ app.get("/result/:type", (req, res) =>
 /* ################# WEBHOOK ###################### */
 
 // Process incoming Webhook: get NotificationRequestItem, validate HMAC signature,
-// consume the event asynchronously, send response ["accepted"]
+// consume the event asynchronously, send response status code 202
 app.post("/api/webhooks/notifications", async (req, res) => {
 
   // YOUR_HMAC_KEY from the Customer Area
@@ -190,7 +190,7 @@ app.post("/api/webhooks/notifications", async (req, res) => {
   }
 
   // acknowledge event has been consumed
-  res.send('[accepted]')
+  res.status(202).send(); // Send a 202 response with an empty body
 
 });
 

--- a/giving-example/index.js
+++ b/giving-example/index.js
@@ -243,7 +243,7 @@ app.get("/result/:type", (req, res) =>
 /* ################# WEBHOOK ###################### */
 
 // Process incoming Webhook: get NotificationRequestItem, validate HMAC signature,
-// consume the event asynchronously, send response ["accepted"]
+// consume the event asynchronously, send response status code 202
 app.post("/api/webhooks/notifications", async (req, res) => {
   console.log("/api/webhooks/notifications");
 
@@ -269,10 +269,10 @@ app.post("/api/webhooks/notifications", async (req, res) => {
     consumeEvent(notification);
 
     // acknowledge event has been consumed
-    res.send('[accepted]')
+    res.status(202).send(); // Send a 202 response with an empty body
 
   } else {
-    // invalid hmac: do not send [accepted] response
+    // invalid hmac
     console.log("Invalid HMAC signature: " + notification);
     res.status(401).send('Invalid HMAC signature');
   }
@@ -280,7 +280,7 @@ app.post("/api/webhooks/notifications", async (req, res) => {
 });
 
 // Process incoming Giving Webhook: get NotificationRequestItem,
-// consume the event asynchronously, send response ["accepted"]
+// consume the event asynchronously, send response status code 202
 app.post("/api/webhooks/giving", async (req, res) => {
   console.log("/api/webhooks/giving");
 
@@ -301,7 +301,7 @@ app.post("/api/webhooks/giving", async (req, res) => {
   consumeEvent(notification);
 
   // acknowledge event has been consumed
-  res.send('[accepted]')
+  res.status(202).send(); // Send a 202 response with an empty body
 
 });
 

--- a/in-person-payments-example/routes/webhookRoute
+++ b/in-person-payments-example/routes/webhookRoute
@@ -10,7 +10,7 @@ const { hmacValidator } = require('@adyen/api-library');
 const { getTableBySaleTransactionId, saveTable } = require('../storage.js')
 
 // Process incoming Webhook: get NotificationRequestItem, validate HMAC signature,
-// consume the event asynchronously, send response ["accepted"]
+// consume the event asynchronously, send response status code 202
 router.post("/", async (req, res) => {
 
     // YOUR_HMAC_KEY from the Customer Area
@@ -32,10 +32,10 @@ router.post("/", async (req, res) => {
         consumeEvent(notification);
 
         // acknowledge event has been consumed
-        res.send('[accepted]')
+        res.status(202).send(); // Send a 202 response with an empty body
 
     } else {
-        // invalid hmac: do not send [accepted] response
+        // invalid hmac
         console.log("Invalid HMAC signature: " + notification);
         res.status(401).send('Invalid HMAC signature');
     }

--- a/paybylink-example/index.js
+++ b/paybylink-example/index.js
@@ -103,7 +103,7 @@ app.get("/", async (req, res) => {
 /* ################# WEBHOOK ###################### */
 
 // Process incoming Webhook: get NotificationRequestItem, validate HMAC signature,
-// consume the event asynchronously, send response ["accepted"]
+// consume the event asynchronously, send response status code 202
 app.post("/api/webhooks/notifications", async (req, res) => {
 
   // YOUR_HMAC_KEY from the Customer Area
@@ -129,10 +129,10 @@ app.post("/api/webhooks/notifications", async (req, res) => {
     consumeEvent(notification);
 
     // acknowledge event has been consumed
-    res.send('[accepted]')
+    res.status(202).send(); // Send a 202 response with an empty body
 
   } else {
-    // invalid hmac: do not send [accepted] response
+    // invalid hmac
     console.log("Invalid HMAC signature: " + notification);
     res.status(401).send('Invalid HMAC signature');
   }

--- a/subscription-example/index.js
+++ b/subscription-example/index.js
@@ -203,7 +203,7 @@ app.get("/admin/disable/:recurringDetailReference", async (req, res) => {
 /* ################# WEBHOOK ###################### */
 
 // Process incoming Webhook: get NotificationRequestItem, validate HMAC signature,
-// consume the event asynchronously, send response ["accepted"]
+// consume the event asynchronously, send response status code 202
 app.post("/api/webhooks/notifications", async (req, res) => {
 
   // YOUR_HMAC_KEY from the Customer Area
@@ -248,9 +248,9 @@ app.post("/api/webhooks/notifications", async (req, res) => {
   } else {
     console.log("Unexpected eventCode: " + notification.eventCode);
   }
-
+  
   // acknowledge event has been consumed
-  res.send('[accepted]')
+  res.status(202).send(); // Send a 202 response with an empty body
 
 });
 


### PR DESCRIPTION
The latest approach to accepting webhooks requires sending the response code `202` and an empty response body.

This PR updates all webhook handlers to implement the new approach.