### PR TITLE
Update Dependabot rebase strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,38 +11,46 @@ updates:
     schedule:
       interval: "daily"
     versioning-strategy: increase
+    rebase-strategy: "disabled"
   - package-ecosystem: "npm" 
     directory: "/checkout-example" 
     schedule:
       interval: "daily"
     versioning-strategy: increase
+    rebase-strategy: "disabled"
   - package-ecosystem: "npm" 
     directory: "/giftcard-example" 
     schedule:
       interval: "daily"
     versioning-strategy: increase
+    rebase-strategy: "disabled"
   - package-ecosystem: "npm" 
     directory: "/paybylink-example" 
     schedule:
       interval: "daily"
     versioning-strategy: increase
+    rebase-strategy: "disabled"
   - package-ecosystem: "npm" 
     directory: "/subscription-example" 
     schedule:
       interval: "daily"
     versioning-strategy: increase
+    rebase-strategy: "disabled"
   - package-ecosystem: "npm" 
     directory: "/authorisation-adjustment-example" 
     schedule:
       interval: "daily"
     versioning-strategy: increase
+    rebase-strategy: "disabled"
   - package-ecosystem: "npm" 
     directory: "/giving-example" 
     schedule:
       interval: "daily"
     versioning-strategy: increase
+    rebase-strategy: "disabled"
   - package-ecosystem: "npm" 
     directory: "/3ds2-example" 
     schedule:
       interval: "daily"
     versioning-strategy: increase
+    rebase-strategy: "disabled"


### PR DESCRIPTION
Update Dependabot configuration to disable the [rebase strategy](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#rebase-strategy): this avoids re-running GitHub actions for all existing PRs when the `main` branch changes (i.e. new code push).