### PR TITLE
Upgrade to iDEAL 2.0

### DIFF
--- a/.github/workflows/e2e-authorisation-adjustment.yml
+++ b/.github/workflows/e2e-authorisation-adjustment.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout authorisation-adjustment-example
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build authorisation-adjustment-example image
         run: docker build -t authorisation-adjustment-example-image:latest authorisation-adjustment-example
       - name: Start authorisation-adjustment-example container

--- a/.github/workflows/e2e-checkout-advanced.yml
+++ b/.github/workflows/e2e-checkout-advanced.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout checkout-example-advanced
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build checkout-example-advanced image
         run: docker build -t checkout-example-advanced-image:latest checkout-example-advanced
       - name: Start checkout-example-advanced container

--- a/.github/workflows/e2e-checkout.yml
+++ b/.github/workflows/e2e-checkout.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout checkout-example
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build checkout-example image
         run: docker build -t checkout-example-image:latest checkout-example
       - name: Start checkout-example container

--- a/.github/workflows/e2e-giftcard.yml
+++ b/.github/workflows/e2e-giftcard.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout giftcard-example
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build giftcard-example image
         run: docker build -t giftcard-example-image:latest giftcard-example
       - name: Start giftcard-example container

--- a/.github/workflows/e2e-giving.yml
+++ b/.github/workflows/e2e-giving.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout giving-example
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build giving-example image
         run: docker build -t giving-example-image:latest giving-example
       - name: Start giving-example container

--- a/.github/workflows/e2e-paybylink.yml
+++ b/.github/workflows/e2e-paybylink.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout paybylink-example
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build paybylink-example image
         run: docker build -t paybylink-example-image:latest paybylink-example
       - name: Start paybylink-example container

--- a/checkout-example-advanced/views/layouts/main.handlebars
+++ b/checkout-example-advanced/views/layouts/main.handlebars
@@ -12,16 +12,16 @@
 
   <link rel="stylesheet" href="/css/application.css">
 
-  <!-- Adyen CSS from TEST environment (change to live for production)-->
-  <link rel="stylesheet"
-        href="https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/5.53.3/adyen.css"
-        integrity="sha384-9EdBqZRrjozkt+Be5ycjHBTi+4DYrafpC1KyPnNyTBfjBIZ5+oMp8BbgvPLGgsE0"
-        crossorigin="anonymous">
-
-  <!-- Adyen JS from TEST environment (change to live for production)-->
-  <script src="https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/5.53.3/adyen.js"
-          integrity="sha384-CSBSWtfdsTY1G+R7kuPLwB9n5wwswxe819nXJSuN75AyCAaajvLh7tMnaIf/2teS"
+	<!-- Adyen JS from TEST environment (change to live for production)-->
+	<script src="https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/5.68.0/adyen.js"
+          integrity="sha384-U9GX6Oa3W024049K86PYG36/jHjkvUqsRd8Y9cF1CmB92sm4tnjxDXF/tkdcsk6k"
           crossorigin="anonymous"></script>
+            
+	<!-- Adyen CSS from TEST environment (change to live for production)-->
+	<link rel="stylesheet"
+        href="https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/5.68.0/adyen.css"
+        integrity="sha384-gpOE6R0K50VgXe6u/pyjzkKl4Kr8hXu93KUCTmC4LqbO9mpoGUYsrmeVLcp2eejn"
+        crossorigin="anonymous">
 
   <title>Checkout Demo Advanced</title>
 </head>

--- a/checkout-example/views/layouts/main.handlebars
+++ b/checkout-example/views/layouts/main.handlebars
@@ -10,15 +10,15 @@
     integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
 
 	<!-- Adyen JS from TEST environment (change to live for production)-->
-	<script src="https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/5.40.0/adyen.js"
-		 integrity="sha384-ds1t0hgFCe636DXFRL6ciadL2Wb4Yihh27R4JO7d9CF7sFY3NJE4aPCK0EpzaYXD"
-		 crossorigin="anonymous"></script>
+	<script src="https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/5.68.0/adyen.js"
+          integrity="sha384-U9GX6Oa3W024049K86PYG36/jHjkvUqsRd8Y9cF1CmB92sm4tnjxDXF/tkdcsk6k"
+          crossorigin="anonymous"></script>
             
 	<!-- Adyen CSS from TEST environment (change to live for production)-->
 	<link rel="stylesheet"
-		 href="https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/5.40.0/adyen.css"
-		 integrity="sha384-BRZCzbS8n6hZVj8BESE6thGk0zSkUZfUWxL/vhocKu12k3NZ7xpNsIK39O2aWuni"
-		 crossorigin="anonymous">
+        href="https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/5.68.0/adyen.css"
+        integrity="sha384-gpOE6R0K50VgXe6u/pyjzkKl4Kr8hXu93KUCTmC4LqbO9mpoGUYsrmeVLcp2eejn"
+        crossorigin="anonymous">
 
   <link rel="stylesheet" href="/css/application.css">
 


### PR DESCRIPTION
Support iDEAL 2.0.

Changes required: update to `Drop-in v5.68.0`

### Note 

- on **TEST** the iDEAL payment method in the Customer Area must be updated to use the `AdyenIdeal` acquirer
- on **LIVE** no changes are required in the Customer Area